### PR TITLE
Fix: Sorting of labeled ImageNet subfolders

### DIFF
--- a/finn_examples/notebooks/2_imagenet_with_cnns.ipynb
+++ b/finn_examples/notebooks/2_imagenet_with_cnns.ipynb
@@ -166,6 +166,7 @@
     "def setup_dataloader(val_path, label_file_path = None, batch_size=100, n_images = 50000):\n",
     "    if label_file_path is None:\n",
     "        val_folders = [ f.name for f in os.scandir(val_path) if f.is_dir() ]\n",
+    "        val_folders = sorted(val_folders)\n",
     "        assert len(val_folders) == 1000, \"Expected 1000 subfolders in ILSVRC2012 val\"\n",
     "        files = []\n",
     "        labels = []\n",


### PR DESCRIPTION
Hotfix: `os.scandir()` does not necessarily return the list of directories in alphabetical order. This could result in incorrect labeling of validation images.