### PR TITLE
Update finn-experimental

### DIFF
--- a/build/get-finn.sh
+++ b/build/get-finn.sh
@@ -30,7 +30,7 @@
 # URL for git repo to be cloned
 REPO_URL=https://github.com/Xilinx/finn
 # commit hash for repo
-REPO_COMMIT=cdc5ec4b0dde59d5d8de0a5359aae529816376af
+REPO_COMMIT=0484acba8e28dab95380bd78466c3d4230bf9960
 # directory (under the same folder as this script) to clone to
 REPO_DIR=finn
 

--- a/build/resnet50/build.py
+++ b/build/resnet50/build.py
@@ -95,13 +95,13 @@ for platform_name in platforms_to_build:
     platform_dir = "release/%s" % release_platform_name
     os.makedirs(platform_dir, exist_ok=True)
 
-    try:
-        from finn.transformation.fpgadataflow.infer_doublepacked_dsp import InferDoublePackedConv
-        folding_config_file="folding_config/U250_folding_config.json"
-        print("DoublePackedConv detected")
-    except:
-        warn(" FINN Experimental not available. Using non-packed folded down convolution. This is 16 times slower per MHz ")
-        folding_config_file="folding_config/U250_folding_config_no_doublepack_pe_folded_16.json"
+#    try:
+#        from finnexperimental.transformation.fpgadataflow.infer_doublepacked_dsp import InferDoublePackedConv
+#        folding_config_file="folding_config/U250_folding_config.json"
+#        print("DoublePackedConv detected")
+#    except:
+#        warn(" FINN Experimental not available. Using non-packed folded down convolution. This is 16 times slower per MHz ")
+    folding_config_file="folding_config/U250_folding_config_no_doublepack_pe_folded_16.json"
 
     cfg = build_cfg.DataflowBuildConfig(
         steps=resnet50_build_steps,

--- a/build/resnet50/custom_steps.py
+++ b/build/resnet50/custom_steps.py
@@ -193,14 +193,14 @@ def step_resnet50_convert_to_hls(model: ModelWrapper, cfg: DataflowBuildConfig):
     model.set_tensor_datatype(model.graph.input[0].name, DataType["UINT8"])
     model = model.transform(InferDataLayouts())
 
-    try:
-        from finn.transformation.fpgadataflow.infer_doublepacked_dsp import (
-            InferDoublePackedConv,
-        )
+#    try:
+#        from finnexperimental.transformation.fpgadataflow.infer_doublepacked_dsp import (
+#            InferDoublePackedConv,
+#        )
 
-        model = model.transform(InferDoublePackedConv([1]))
-    except Exception:
-        print(" FINN Experimental not available. Using non-packed convolution ")
+#        model = model.transform(InferDoublePackedConv([1]))
+#    except Exception:
+#        print(" FINN Experimental not available. Using non-packed convolution ")
 
     model = model.transform(DoubleToSingleFloat())
     model = model.transform(InferDataTypes())
@@ -299,7 +299,7 @@ def step_resnet50_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig)
 def step_resnet50_slr_floorplan(model: ModelWrapper, cfg: DataflowBuildConfig):
     if cfg.shell_flow_type == ShellFlowType.VITIS_ALVEO:
         try:
-            from finn.analysis.partitioning import partition
+            from finnexperimental.analysis.partitioning import partition
 
             # apply partitioning of the model, restricting the first and last layers
             # to SLR0


### PR DESCRIPTION
Because of a namespace conflict and outdated HLS code, finn-experimental temporarily wasn't usable. This PR updates the FINN commit version that allows to use finn-experimental again and updates to the `build.py` and `custom_steps.py` from the ResNet to the new namespace of finn-experimental.