### PR TITLE
rename the VGG10 bitstream to match models.py

### DIFF
--- a/build/vgg10-radioml/build.py
+++ b/build/vgg10-radioml/build.py
@@ -35,7 +35,7 @@ import shutil
 # custom steps
 from custom_steps import step_pre_streamline, step_convert_final_layers
 
-model_name = "radioml_w4a4_small_tidy"
+model_name = "vgg10-radioml-w4a4"
 
 # which platforms to build the networks for
 zynq_platforms = ["ZCU104"]


### PR DESCRIPTION
This is needed so that https://github.com/Xilinx/finn-examples/blob/main/finn_examples/notebooks/5_radioml_with_cnns.ipynb can retrieve the equivalent built bitstream (not the released bitstream) from here: https://github.com/Xilinx/finn-examples/blob/c75c1168b84a3e40b6ce68fc8ac6aef99fab81f3/finn_examples/models.py#L338
