### PR TITLE
Re-enable experimental partitioning feature for ResNet-50 build

### DIFF
--- a/build/get-finn.sh
+++ b/build/get-finn.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Copyright (c) 2020, Xilinx
+# Copyright (C) 2020-2022, Xilinx
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,7 +31,7 @@
 # URL for git repo to be cloned
 REPO_URL=https://github.com/Xilinx/finn
 # commit hash for repo
-REPO_COMMIT=0484acba8e28dab95380bd78466c3d4230bf9960
+REPO_COMMIT=297fa3dbaa327d4eeeb26f789e5312a8dd3511f4
 # directory (under the same folder as this script) to clone to
 REPO_DIR=finn
 

--- a/build/get-finn.sh
+++ b/build/get-finn.sh
@@ -31,7 +31,7 @@
 # URL for git repo to be cloned
 REPO_URL=https://github.com/Xilinx/finn
 # commit hash for repo
-REPO_COMMIT=297fa3dbaa327d4eeeb26f789e5312a8dd3511f4
+REPO_COMMIT=02ce6954c93963c8407cd5c20761fccf92e1c70d
 # directory (under the same folder as this script) to clone to
 REPO_DIR=finn
 


### PR DESCRIPTION
This PR re-enables the partitioning feature of finn-experimental for ResNet-50. The finn commit is updated in get-finn.sh which will pull changes on the finn repo and also update the used finn-experimental version.

Before merging, Xilinx/finn#920 on the finn repo will need to be tested and merged. Then there is a final commit hash update needed in get-finn.sh before this PR can be merged.