### PR TITLE
Bugfix/fix package init

### DIFF
--- a/finn_examples/__init__.py
+++ b/finn_examples/__init__.py
@@ -38,13 +38,17 @@
 import sys
 
 import finn_examples.qonnx as qonnx
+
 sys.modules["qonnx"] = qonnx
 
-import finn_examples.qonnx.core.datatype as datatype
+import finn_examples.qonnx.core.datatype as datatype  # noqa: E402
+
 sys.modules["qonnx.core.datatype"] = datatype
 
-import finn_examples.qonnx.util.basic as basic
+import finn_examples.qonnx.util.basic as basic  # noqa: E402
+
 sys.modules["qonnx.util.basic"] = basic
 
-import finn_examples.finn.util.data_packing as data_packing
+import finn_examples.finn.util.data_packing as data_packing  # noqa: E402
+
 sys.modules["finn.util.data_packing"] = data_packing

--- a/finn_examples/__init__.py
+++ b/finn_examples/__init__.py
@@ -37,12 +37,14 @@
 
 import sys
 
-import finn_examples.finn.util.data_packing as data_packing
 import finn_examples.qonnx as qonnx
-import finn_examples.qonnx.core.datatype as datatype
-import finn_examples.qonnx.util.basic as basic
-
 sys.modules["qonnx"] = qonnx
+
+import finn_examples.qonnx.core.datatype as datatype
 sys.modules["qonnx.core.datatype"] = datatype
+
+import finn_examples.qonnx.util.basic as basic
 sys.modules["qonnx.util.basic"] = basic
+
+import finn_examples.finn.util.data_packing as data_packing
 sys.modules["finn.util.data_packing"] = data_packing


### PR DESCRIPTION
Linting of finn-examples/__init__.py broke the package install. Reverting linting and ignoring the linting errors. 