### PR TITLE
Update MobileNet-v1 flows to FINN v0.10

### DIFF
--- a/build/mobilenet-v1/build.py
+++ b/build/mobilenet-v1/build.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2020, Xilinx
+# Copyright (C) 2020-2022, Xilinx, Inc.
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -45,7 +46,7 @@ model_name = "mobilenetv1-w4a4"
 
 # which platforms to build the networks for
 zynq_platforms = ["ZCU102", "ZCU104"]
-alveo_platforms = []  # "U50", "U200", "U250", "U280"]
+alveo_platforms = ["U50", "U200", "U250", "U280"]
 platforms_to_build = zynq_platforms + alveo_platforms
 
 

--- a/build/mobilenet-v1/build.py
+++ b/build/mobilenet-v1/build.py
@@ -45,8 +45,8 @@ from custom_steps import (
 model_name = "mobilenetv1-w4a4"
 
 # which platforms to build the networks for
-zynq_platforms = ["ZCU102", "ZCU104"]
-alveo_platforms = ["U50", "U200", "U250", "U280"]
+zynq_platforms = ["ZCU104"]  # "ZCU104"
+alveo_platforms = ["U250"]  # "U50", "U200", "U280"
 platforms_to_build = zynq_platforms + alveo_platforms
 
 

--- a/build/mobilenet-v1/build.py
+++ b/build/mobilenet-v1/build.py
@@ -44,10 +44,8 @@ from custom_steps import (
 model_name = "mobilenetv1-w4a4"
 
 # which platforms to build the networks for
-# zynq_platforms = ["ZCU102", "ZCU104"]
-zynq_platforms = ["ZCU102"]
-# alveo_platforms = ["U50", "U200", "U250", "U280"]
-alveo_platforms = ["U250"]
+zynq_platforms = ["ZCU102", "ZCU104"]
+alveo_platforms = []  # "U50", "U200", "U250", "U280"]
 platforms_to_build = zynq_platforms + alveo_platforms
 
 
@@ -132,7 +130,8 @@ for platform_name in platforms_to_build:
         steps=select_build_steps(platform_name),
         output_dir="output_%s_%s" % (model_name, release_platform_name),
         folding_config_file="folding_config/%s_folding_config.json" % platform_name,
-        specialize_layers_config_file="specialize_layers_config.json",
+        specialize_layers_config_file="specialize_layers_config/%s_specialize_layers_config.json"
+        % platform_name,
         synth_clk_period_ns=select_clk_period(platform_name),
         board=platform_name,
         shell_flow_type=shell_flow_type,

--- a/build/mobilenet-v1/custom_steps.py
+++ b/build/mobilenet-v1/custom_steps.py
@@ -103,7 +103,7 @@ def step_mobilenet_convert_to_hw_layers(model: ModelWrapper, cfg: DataflowBuildC
 def step_mobilenet_slr_floorplan(model: ModelWrapper, cfg: DataflowBuildConfig):
     if cfg.shell_flow_type == ShellFlowType.VITIS_ALVEO:
         try:
-            from finn.analysis.partitioning import partition
+            from finnexperimental.analysis.partitioning import partition
 
             # apply partitioning of the model, restricting the first and last layers
             # to SLR0

--- a/build/mobilenet-v1/folding_config/U200_folding_config.json
+++ b/build/mobilenet-v1/folding_config/U200_folding_config.json
@@ -2,9 +2,10 @@
   "Defaults": {},
   "StreamingFIFO_rtl_0": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_0": {
+  "ConvolutionInputGenerator_rtl_0": {
     "SIMD": 3,
     "ram_style": "distributed"
   },
@@ -13,20 +14,21 @@
     "SIMD": 3,
     "ram_style": "block",
     "mem_mode": "internal_decoupled",
-    "resType": "lut"
+    "resType": "dsp"
   },
-  "FMPadding_hls_0": {
+  "FMPadding_rtl_0": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_3": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "ConvolutionInputGenerator_hls_1": {
+  "ConvolutionInputGenerator_rtl_1": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_0": {
+  "VVAU_hls_0": {
     "PE": 32,
     "resType": "lut"
   },
@@ -37,47 +39,54 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_1": {
+  "FMPadding_rtl_1": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_9": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_2": {
+  "ConvolutionInputGenerator_rtl_2": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_1": {
+  "VVAU_hls_1": {
     "PE": 32,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_12": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_2": {
     "PE": 16,
+    "SIMD": 16,
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_2": {
+  "FMPadding_rtl_2": {
     "SIMD": 64
   },
   "StreamingFIFO_rtl_15": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "ConvolutionInputGenerator_hls_3": {
+  "ConvolutionInputGenerator_rtl_3": {
     "SIMD": 64,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_2": {
+  "VVAU_hls_2": {
     "PE": 64,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_18": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_3": {
     "PE": 32,
@@ -88,26 +97,29 @@
   },
   "StreamingFIFO_rtl_20": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_3": {
+  "FMPadding_rtl_3": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_21": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_4": {
+  "ConvolutionInputGenerator_rtl_4": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_3": {
+  "VVAU_hls_3": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_23": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_4": {
     "PE": 16,
@@ -116,24 +128,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_4": {
+  "FMPadding_rtl_4": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_26": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_5": {
+  "ConvolutionInputGenerator_rtl_5": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_4": {
+  "VVAU_hls_4": {
     "PE": 32,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_29": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_5": {
     "PE": 32,
@@ -144,26 +158,29 @@
   },
   "StreamingFIFO_rtl_31": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_5": {
+  "FMPadding_rtl_5": {
     "SIMD": 8
   },
   "StreamingFIFO_rtl_32": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_6": {
+  "ConvolutionInputGenerator_rtl_6": {
     "SIMD": 8,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_5": {
+  "VVAU_hls_5": {
     "PE": 8,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_35": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_6": {
     "PE": 16,
@@ -172,24 +189,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_6": {
+  "FMPadding_rtl_6": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_37": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_7": {
+  "ConvolutionInputGenerator_rtl_7": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_6": {
+  "VVAU_hls_6": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_39": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_7": {
     "PE": 32,
@@ -200,26 +219,29 @@
   },
   "StreamingFIFO_rtl_41": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_7": {
+  "FMPadding_rtl_7": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_42": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_8": {
+  "ConvolutionInputGenerator_rtl_8": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_7": {
+  "VVAU_hls_7": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_44": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_8": {
     "PE": 32,
@@ -230,26 +252,29 @@
   },
   "StreamingFIFO_rtl_46": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_8": {
+  "FMPadding_rtl_8": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_47": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_9": {
+  "ConvolutionInputGenerator_rtl_9": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_8": {
+  "VVAU_hls_8": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_49": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_9": {
     "PE": 32,
@@ -260,26 +285,29 @@
   },
   "StreamingFIFO_rtl_51": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_9": {
+  "FMPadding_rtl_9": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_52": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_10": {
+  "ConvolutionInputGenerator_rtl_10": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_9": {
+  "VVAU_hls_9": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_54": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_10": {
     "PE": 32,
@@ -290,26 +318,29 @@
   },
   "StreamingFIFO_rtl_56": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_10": {
+  "FMPadding_rtl_10": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_57": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_11": {
+  "ConvolutionInputGenerator_rtl_11": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_10": {
+  "VVAU_hls_10": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_59": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_11": {
     "PE": 32,
@@ -320,26 +351,29 @@
   },
   "StreamingFIFO_rtl_61": {
     "ram_style": "auto",
-    "depth": 128
+    "depth": 128,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_11": {
+  "FMPadding_rtl_11": {
     "SIMD": 4
   },
   "StreamingFIFO_rtl_62": {
     "ram_style": "ultra",
-    "depth": 4096
+    "depth": 4096,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_12": {
+  "ConvolutionInputGenerator_rtl_12": {
     "SIMD": 4,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_11": {
+  "VVAU_hls_11": {
     "PE": 4,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_65": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_12": {
     "PE": 16,
@@ -350,26 +384,29 @@
   },
   "StreamingFIFO_rtl_67": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_12": {
+  "FMPadding_rtl_12": {
     "SIMD": 8
   },
   "StreamingFIFO_rtl_68": {
     "ram_style": "ultra",
-    "depth": 4096
+    "depth": 4096,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_13": {
+  "ConvolutionInputGenerator_rtl_13": {
     "SIMD": 8,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_12": {
+  "VVAU_hls_12": {
     "PE": 8,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_71": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_13": {
     "PE": 32,
@@ -378,7 +415,7 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "ConvolutionInputGenerator_hls_14": {
+  "ConvolutionInputGenerator_rtl_14": {
     "SIMD": 4,
     "ram_style": "distributed"
   },

--- a/build/mobilenet-v1/folding_config/U250_folding_config.json
+++ b/build/mobilenet-v1/folding_config/U250_folding_config.json
@@ -1,323 +1,437 @@
 {
   "Defaults": {},
   "StreamingFIFO_rtl_0": {
-    "depth": 512
+    "ram_style": "ultra",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_0": {
-    "SIMD": 3
+    "SIMD": 3,
+    "ram_style": "distributed"
   },
-  "MVAU_rtl_0": {
+  "MVAU_hls_0": {
     "PE": 32,
     "SIMD": 3,
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
     "resType": "dsp"
   },
   "FMPadding_rtl_0": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_3": {
-    "depth": 256
+    "ram_style": "auto",
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "ConvolutionInputGenerator_rtl_1": {
-    "SIMD": 32
+    "SIMD": 32,
+    "ram_style": "distributed"
   },
   "VVAU_hls_0": {
     "PE": 32,
     "resType": "lut"
   },
-  "MVAU_rtl_1": {
+  "MVAU_hls_1": {
     "PE": 16,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "FMPadding_rtl_1": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_9": {
-    "depth": 512
+    "ram_style": "ultra",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_2": {
-    "SIMD": 32
+    "SIMD": 32,
+    "ram_style": "distributed"
   },
   "VVAU_hls_1": {
     "PE": 32,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_12": {
-    "depth": 256
+    "ram_style": "auto",
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "MVAU_rtl_2": {
+  "MVAU_hls_2": {
     "PE": 16,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "FMPadding_rtl_2": {
     "SIMD": 64
   },
   "StreamingFIFO_rtl_15": {
-    "depth": 256
+    "ram_style": "auto",
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "ConvolutionInputGenerator_rtl_3": {
-    "SIMD": 64
+    "SIMD": 64,
+    "ram_style": "distributed"
   },
   "VVAU_hls_2": {
     "PE": 64,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_18": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "MVAU_rtl_3": {
+  "MVAU_hls_3": {
     "PE": 32,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "StreamingFIFO_rtl_20": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_3": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_21": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_4": {
-    "SIMD": 16
+    "SIMD": 16,
+    "ram_style": "distributed"
   },
   "VVAU_hls_3": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_23": {
-    "depth": 256
+    "ram_style": "auto",
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "MVAU_rtl_4": {
+  "MVAU_hls_4": {
     "PE": 16,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "FMPadding_rtl_4": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_26": {
-    "depth": 512
+    "ram_style": "ultra",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_5": {
-    "SIMD": 32
+    "SIMD": 32,
+    "ram_style": "distributed"
   },
   "VVAU_hls_4": {
     "PE": 32,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_29": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "MVAU_rtl_5": {
+  "MVAU_hls_5": {
     "PE": 32,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "StreamingFIFO_rtl_31": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_5": {
     "SIMD": 8
   },
   "StreamingFIFO_rtl_32": {
-    "depth": 2048
+    "ram_style": "ultra",
+    "depth": 2048,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_6": {
-    "SIMD": 8
+    "SIMD": 8,
+    "ram_style": "distributed"
   },
   "VVAU_hls_5": {
     "PE": 8,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_35": {
-    "depth": 256
+    "ram_style": "auto",
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "MVAU_rtl_6": {
+  "MVAU_hls_6": {
     "PE": 16,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "FMPadding_rtl_6": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_37": {
-    "depth": 2048
+    "ram_style": "ultra",
+    "depth": 2048,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_7": {
-    "SIMD": 16
+    "SIMD": 16,
+    "ram_style": "distributed"
   },
   "VVAU_hls_6": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_39": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "MVAU_rtl_7": {
+  "MVAU_hls_7": {
     "PE": 32,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "StreamingFIFO_rtl_41": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_7": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_42": {
-    "depth": 2048
+    "ram_style": "ultra",
+    "depth": 2048,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_8": {
-    "SIMD": 16
+    "SIMD": 16,
+    "ram_style": "distributed"
   },
   "VVAU_hls_7": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_44": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "MVAU_rtl_8": {
+  "MVAU_hls_8": {
     "PE": 32,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "StreamingFIFO_rtl_46": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_8": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_47": {
-    "depth": 2048
+    "ram_style": "ultra",
+    "depth": 2048,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_9": {
-    "SIMD": 16
+    "SIMD": 16,
+    "ram_style": "distributed"
   },
   "VVAU_hls_8": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_49": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "MVAU_rtl_9": {
+  "MVAU_hls_9": {
     "PE": 32,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "StreamingFIFO_rtl_51": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_9": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_52": {
-    "depth": 2048
+    "ram_style": "ultra",
+    "depth": 2048,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_10": {
-    "SIMD": 16
+    "SIMD": 16,
+    "ram_style": "distributed"
   },
   "VVAU_hls_9": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_54": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "MVAU_rtl_10": {
+  "MVAU_hls_10": {
     "PE": 32,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "StreamingFIFO_rtl_56": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_10": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_57": {
-    "depth": 2048
+    "ram_style": "ultra",
+    "depth": 2048,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_11": {
-    "SIMD": 16
+    "SIMD": 16,
+    "ram_style": "distributed"
   },
   "VVAU_hls_10": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_59": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "MVAU_rtl_11": {
+  "MVAU_hls_11": {
     "PE": 32,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "StreamingFIFO_rtl_61": {
-    "depth": 128
+    "ram_style": "auto",
+    "depth": 128,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_11": {
     "SIMD": 4
   },
   "StreamingFIFO_rtl_62": {
-    "depth": 4096
+    "ram_style": "ultra",
+    "depth": 4096,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_12": {
-    "SIMD": 4
+    "SIMD": 4,
+    "ram_style": "distributed"
   },
   "VVAU_hls_11": {
     "PE": 4,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_65": {
-    "depth": 256
+    "ram_style": "auto",
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "MVAU_rtl_12": {
+  "MVAU_hls_12": {
     "PE": 16,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "StreamingFIFO_rtl_67": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_12": {
     "SIMD": 8
   },
   "StreamingFIFO_rtl_68": {
-    "depth": 4096
+    "ram_style": "ultra",
+    "depth": 4096,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_13": {
-    "SIMD": 8
+    "SIMD": 8,
+    "ram_style": "distributed"
   },
   "VVAU_hls_12": {
     "PE": 8,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_71": {
-    "depth": 1024
+    "ram_style": "ultra",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "MVAU_rtl_13": {
+  "MVAU_hls_13": {
     "PE": 32,
     "SIMD": 16,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "ConvolutionInputGenerator_rtl_14": {
-    "SIMD": 4
+    "SIMD": 4,
+    "ram_style": "distributed"
   },
   "Pool_hls_0": {
     "PE": 4
   },
-  "MVAU_rtl_14": {
+  "MVAU_hls_14": {
     "PE": 4,
     "SIMD": 4,
-    "resType": "dsp"
+    "ram_style": "block",
+    "mem_mode": "internal_decoupled",
+    "resType": "lut"
   },
   "ChannelwiseOp_hls_0": {
-    "PE": 1
+    "PE": 1,
+    "ram_style": "distributed"
   },
   "LabelSelect_hls_0": {
     "PE": 1

--- a/build/mobilenet-v1/folding_config/U280_folding_config.json
+++ b/build/mobilenet-v1/folding_config/U280_folding_config.json
@@ -2,9 +2,10 @@
   "Defaults": {},
   "StreamingFIFO_rtl_0": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_0": {
+  "ConvolutionInputGenerator_rtl_0": {
     "SIMD": 3,
     "ram_style": "distributed"
   },
@@ -13,20 +14,21 @@
     "SIMD": 3,
     "ram_style": "block",
     "mem_mode": "internal_decoupled",
-    "resType": "lut"
+    "resType": "dsp"
   },
-  "FMPadding_hls_0": {
+  "FMPadding_rtl_0": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_3": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "ConvolutionInputGenerator_hls_1": {
+  "ConvolutionInputGenerator_rtl_1": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_0": {
+  "VVAU_hls_0": {
     "PE": 32,
     "resType": "lut"
   },
@@ -37,24 +39,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_1": {
+  "FMPadding_rtl_1": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_9": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_2": {
+  "ConvolutionInputGenerator_rtl_2": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_1": {
+  "VVAU_hls_1": {
     "PE": 32,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_12": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_2": {
     "PE": 16,
@@ -63,24 +67,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_2": {
+  "FMPadding_rtl_2": {
     "SIMD": 64
   },
   "StreamingFIFO_rtl_15": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "ConvolutionInputGenerator_hls_3": {
+  "ConvolutionInputGenerator_rtl_3": {
     "SIMD": 64,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_2": {
+  "VVAU_hls_2": {
     "PE": 64,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_18": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_3": {
     "PE": 32,
@@ -91,26 +97,29 @@
   },
   "StreamingFIFO_rtl_20": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_3": {
+  "FMPadding_rtl_3": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_21": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_4": {
+  "ConvolutionInputGenerator_rtl_4": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_3": {
+  "VVAU_hls_3": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_23": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_4": {
     "PE": 16,
@@ -119,24 +128,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_4": {
+  "FMPadding_rtl_4": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_26": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_5": {
+  "ConvolutionInputGenerator_rtl_5": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_4": {
+  "VVAU_hls_4": {
     "PE": 32,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_29": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_5": {
     "PE": 32,
@@ -147,26 +158,29 @@
   },
   "StreamingFIFO_rtl_31": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_5": {
+  "FMPadding_rtl_5": {
     "SIMD": 8
   },
   "StreamingFIFO_rtl_32": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_6": {
+  "ConvolutionInputGenerator_rtl_6": {
     "SIMD": 8,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_5": {
+  "VVAU_hls_5": {
     "PE": 8,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_35": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_6": {
     "PE": 16,
@@ -175,24 +189,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_6": {
+  "FMPadding_rtl_6": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_37": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_7": {
+  "ConvolutionInputGenerator_rtl_7": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_6": {
+  "VVAU_hls_6": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_39": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_7": {
     "PE": 32,
@@ -203,26 +219,29 @@
   },
   "StreamingFIFO_rtl_41": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_7": {
+  "FMPadding_rtl_7": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_42": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_8": {
+  "ConvolutionInputGenerator_rtl_8": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_7": {
+  "VVAU_hls_7": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_44": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_8": {
     "PE": 32,
@@ -233,26 +252,29 @@
   },
   "StreamingFIFO_rtl_46": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_8": {
+  "FMPadding_rtl_8": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_47": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_9": {
+  "ConvolutionInputGenerator_rtl_9": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_8": {
+  "VVAU_hls_8": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_49": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_9": {
     "PE": 32,
@@ -263,26 +285,29 @@
   },
   "StreamingFIFO_rtl_51": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_9": {
+  "FMPadding_rtl_9": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_52": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_10": {
+  "ConvolutionInputGenerator_rtl_10": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_9": {
+  "VVAU_hls_9": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_54": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_10": {
     "PE": 32,
@@ -293,26 +318,29 @@
   },
   "StreamingFIFO_rtl_56": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_10": {
+  "FMPadding_rtl_10": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_57": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_11": {
+  "ConvolutionInputGenerator_rtl_11": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_10": {
+  "VVAU_hls_10": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_59": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_11": {
     "PE": 32,
@@ -323,26 +351,29 @@
   },
   "StreamingFIFO_rtl_61": {
     "ram_style": "auto",
-    "depth": 128
+    "depth": 128,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_11": {
+  "FMPadding_rtl_11": {
     "SIMD": 4
   },
   "StreamingFIFO_rtl_62": {
     "ram_style": "ultra",
-    "depth": 4096
+    "depth": 4096,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_12": {
+  "ConvolutionInputGenerator_rtl_12": {
     "SIMD": 4,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_11": {
+  "VVAU_hls_11": {
     "PE": 4,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_65": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_12": {
     "PE": 16,
@@ -353,26 +384,29 @@
   },
   "StreamingFIFO_rtl_67": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_12": {
+  "FMPadding_rtl_12": {
     "SIMD": 8
   },
   "StreamingFIFO_rtl_68": {
     "ram_style": "ultra",
-    "depth": 4096
+    "depth": 4096,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_13": {
+  "ConvolutionInputGenerator_rtl_13": {
     "SIMD": 8,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_12": {
+  "VVAU_hls_12": {
     "PE": 8,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_71": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_13": {
     "PE": 32,
@@ -381,7 +415,7 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "ConvolutionInputGenerator_hls_14": {
+  "ConvolutionInputGenerator_rtl_14": {
     "SIMD": 4,
     "ram_style": "distributed"
   },

--- a/build/mobilenet-v1/folding_config/U50_folding_config.json
+++ b/build/mobilenet-v1/folding_config/U50_folding_config.json
@@ -2,9 +2,10 @@
   "Defaults": {},
   "StreamingFIFO_rtl_0": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_0": {
+  "ConvolutionInputGenerator_rtl_0": {
     "SIMD": 3,
     "ram_style": "distributed"
   },
@@ -13,20 +14,21 @@
     "SIMD": 3,
     "ram_style": "block",
     "mem_mode": "internal_decoupled",
-    "resType": "lut"
+    "resType": "dsp"
   },
-  "FMPadding_hls_0": {
+  "FMPadding_rtl_0": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_3": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "ConvolutionInputGenerator_hls_1": {
+  "ConvolutionInputGenerator_rtl_1": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_0": {
+  "VVAU_hls_0": {
     "PE": 32,
     "resType": "lut"
   },
@@ -37,24 +39,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_1": {
+  "FMPadding_rtl_1": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_9": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_2": {
+  "ConvolutionInputGenerator_rtl_2": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_1": {
+  "VVAU_hls_1": {
     "PE": 32,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_12": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_2": {
     "PE": 16,
@@ -63,24 +67,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_2": {
+  "FMPadding_rtl_2": {
     "SIMD": 64
   },
   "StreamingFIFO_rtl_15": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
-  "ConvolutionInputGenerator_hls_3": {
+  "ConvolutionInputGenerator_rtl_3": {
     "SIMD": 64,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_2": {
+  "VVAU_hls_2": {
     "PE": 64,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_18": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_3": {
     "PE": 32,
@@ -91,26 +97,29 @@
   },
   "StreamingFIFO_rtl_20": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_3": {
+  "FMPadding_rtl_3": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_21": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_4": {
+  "ConvolutionInputGenerator_rtl_4": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_3": {
+  "VVAU_hls_3": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_23": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_4": {
     "PE": 16,
@@ -119,24 +128,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_4": {
+  "FMPadding_rtl_4": {
     "SIMD": 32
   },
   "StreamingFIFO_rtl_26": {
     "ram_style": "ultra",
-    "depth": 512
+    "depth": 512,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_5": {
+  "ConvolutionInputGenerator_rtl_5": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_4": {
+  "VVAU_hls_4": {
     "PE": 32,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_29": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_5": {
     "PE": 32,
@@ -147,26 +158,29 @@
   },
   "StreamingFIFO_rtl_31": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_5": {
+  "FMPadding_rtl_5": {
     "SIMD": 8
   },
   "StreamingFIFO_rtl_32": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_6": {
+  "ConvolutionInputGenerator_rtl_6": {
     "SIMD": 8,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_5": {
+  "VVAU_hls_5": {
     "PE": 8,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_35": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_6": {
     "PE": 16,
@@ -175,24 +189,26 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "FMPadding_hls_6": {
+  "FMPadding_rtl_6": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_37": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_7": {
+  "ConvolutionInputGenerator_rtl_7": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_6": {
+  "VVAU_hls_6": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_39": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_7": {
     "PE": 32,
@@ -203,26 +219,29 @@
   },
   "StreamingFIFO_rtl_41": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_7": {
+  "FMPadding_rtl_7": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_42": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_8": {
+  "ConvolutionInputGenerator_rtl_8": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_7": {
+  "VVAU_hls_7": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_44": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_8": {
     "PE": 32,
@@ -233,26 +252,29 @@
   },
   "StreamingFIFO_rtl_46": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_8": {
+  "FMPadding_rtl_8": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_47": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_9": {
+  "ConvolutionInputGenerator_rtl_9": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_8": {
+  "VVAU_hls_8": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_49": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_9": {
     "PE": 32,
@@ -263,26 +285,29 @@
   },
   "StreamingFIFO_rtl_51": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_9": {
+  "FMPadding_rtl_9": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_52": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_10": {
+  "ConvolutionInputGenerator_rtl_10": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_9": {
+  "VVAU_hls_9": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_54": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_10": {
     "PE": 32,
@@ -293,26 +318,29 @@
   },
   "StreamingFIFO_rtl_56": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_10": {
+  "FMPadding_rtl_10": {
     "SIMD": 16
   },
   "StreamingFIFO_rtl_57": {
     "ram_style": "ultra",
-    "depth": 2048
+    "depth": 2048,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_11": {
+  "ConvolutionInputGenerator_rtl_11": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_10": {
+  "VVAU_hls_10": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_59": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_11": {
     "PE": 32,
@@ -323,26 +351,29 @@
   },
   "StreamingFIFO_rtl_61": {
     "ram_style": "auto",
-    "depth": 128
+    "depth": 128,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_11": {
+  "FMPadding_rtl_11": {
     "SIMD": 4
   },
   "StreamingFIFO_rtl_62": {
     "ram_style": "ultra",
-    "depth": 4096
+    "depth": 4096,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_12": {
+  "ConvolutionInputGenerator_rtl_12": {
     "SIMD": 4,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_11": {
+  "VVAU_hls_11": {
     "PE": 4,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_65": {
     "ram_style": "auto",
-    "depth": 256
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "MVAU_hls_12": {
     "PE": 16,
@@ -353,26 +384,29 @@
   },
   "StreamingFIFO_rtl_67": {
     "ram_style": "auto",
-    "depth": 32
+    "depth": 32,
+    "impl_style": "rtl"
   },
-  "FMPadding_hls_12": {
+  "FMPadding_rtl_12": {
     "SIMD": 8
   },
   "StreamingFIFO_rtl_68": {
     "ram_style": "ultra",
-    "depth": 4096
+    "depth": 4096,
+    "impl_style": "vivado"
   },
-  "ConvolutionInputGenerator_hls_13": {
+  "ConvolutionInputGenerator_rtl_13": {
     "SIMD": 8,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_12": {
+  "VVAU_hls_12": {
     "PE": 8,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_71": {
     "ram_style": "ultra",
-    "depth": 1024
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "MVAU_hls_13": {
     "PE": 32,
@@ -381,7 +415,7 @@
     "mem_mode": "internal_decoupled",
     "resType": "lut"
   },
-  "ConvolutionInputGenerator_hls_14": {
+  "ConvolutionInputGenerator_rtl_14": {
     "SIMD": 4,
     "ram_style": "distributed"
   },

--- a/build/mobilenet-v1/folding_config/ZCU102_folding_config.json
+++ b/build/mobilenet-v1/folding_config/ZCU102_folding_config.json
@@ -1,455 +1,553 @@
 {
   "Defaults": {},
   "StreamingFIFO_rtl_0": {
-    "depth": 1024
+    "ram_style": "block",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_0": {
-    "SIMD": 1
+    "SIMD": 1,
+    "ram_style": "distributed"
   },
   "MVAU_rtl_0": {
     "PE": 16,
     "SIMD": 3,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "StreamingFIFO_rtl_3": {
-    "depth": 64
+    "ram_style": "auto",
+    "depth": 64,
+    "impl_style": "rtl"
   },
   "Thresholding_rtl_0": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_6": {
-    "depth": 256
+    "ram_style": "auto",
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_0": {
     "SIMD": 2
   },
   "StreamingFIFO_rtl_8": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_1": {
-    "SIMD": 16
+    "SIMD": 16,
+    "ram_style": "distributed"
   },
   "VVAU_hls_0": {
     "PE": 16,
     "resType": "lut"
   },
   "StreamingFIFO_rtl_10": {
-    "depth": 256
+    "ram_style": "auto",
+    "depth": 256,
+    "impl_style": "rtl"
   },
   "Thresholding_rtl_1": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "MVAU_rtl_1": {
     "PE": 8,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_2": {
-    "PE": 2,
-    "runtime_writeable_weights": 0
+    "PE": 2
   },
   "StreamingFIFO_rtl_17": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_1": {
     "SIMD": 4
   },
   "StreamingFIFO_rtl_19": {
-    "depth": 1024
+    "ram_style": "block",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_2": {
-    "SIMD": 8
+    "SIMD": 8,
+    "ram_style": "distributed"
   },
   "VVAU_hls_1": {
     "PE": 8,
     "resType": "lut"
   },
   "Thresholding_rtl_3": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_24": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_2": {
     "PE": 16,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_4": {
-    "PE": 2,
-    "runtime_writeable_weights": 0
+    "PE": 2
   },
   "StreamingFIFO_rtl_27": {
-    "depth": 128
+    "ram_style": "auto",
+    "depth": 128,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_2": {
     "SIMD": 2
   },
   "StreamingFIFO_rtl_29": {
-    "depth": 1024
+    "ram_style": "block",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_3": {
-    "SIMD": 16
+    "SIMD": 16,
+    "ram_style": "distributed"
   },
   "VVAU_hls_2": {
     "PE": 16,
     "resType": "lut"
   },
   "Thresholding_rtl_5": {
-    "PE": 2,
-    "runtime_writeable_weights": 0
+    "PE": 2
   },
   "StreamingFIFO_rtl_34": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_3": {
     "PE": 32,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_6": {
-    "PE": 2,
-    "runtime_writeable_weights": 0
+    "PE": 2
   },
   "StreamingFIFO_rtl_37": {
-    "depth": 128
+    "ram_style": "auto",
+    "depth": 128,
+    "impl_style": "rtl"
   },
   "FMPadding_rtl_3": {
     "SIMD": 2
   },
   "StreamingFIFO_rtl_39": {
-    "depth": 4096
+    "ram_style": "block",
+    "depth": 4096,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_4": {
-    "SIMD": 4
+    "SIMD": 4,
+    "ram_style": "distributed"
   },
   "VVAU_hls_3": {
     "PE": 4,
     "resType": "lut"
   },
   "Thresholding_rtl_7": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_44": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_4": {
     "PE": 16,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_8": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_47": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_4": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_49": {
-    "depth": 1024
+    "ram_style": "block",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_5": {
-    "SIMD": 8
+    "SIMD": 8,
+    "ram_style": "distributed"
   },
   "VVAU_hls_4": {
     "PE": 8,
     "resType": "lut"
   },
   "Thresholding_rtl_9": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_54": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_5": {
     "PE": 32,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_10": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_57": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_5": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_59": {
-    "depth": 8192
+    "ram_style": "block",
+    "depth": 8192,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_6": {
-    "SIMD": 2
+    "SIMD": 2,
+    "ram_style": "distributed"
   },
   "VVAU_hls_5": {
     "PE": 2,
     "resType": "lut"
   },
   "Thresholding_rtl_11": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_64": {
-    "depth": 32
+    "ram_style": "auto",
+    "depth": 32,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_6": {
     "PE": 16,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_12": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_67": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_6": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_69": {
-    "depth": 4096
+    "ram_style": "block",
+    "depth": 4096,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_7": {
-    "SIMD": 4
+    "SIMD": 4,
+    "ram_style": "distributed"
   },
   "VVAU_hls_6": {
     "PE": 4,
     "resType": "lut"
   },
   "Thresholding_rtl_13": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_74": {
-    "depth": 64
+    "ram_style": "auto",
+    "depth": 64,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_7": {
     "PE": 32,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_14": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_77": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_7": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_79": {
-    "depth": 4096
+    "ram_style": "block",
+    "depth": 4096,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_8": {
-    "SIMD": 4
+    "SIMD": 4,
+    "ram_style": "distributed"
   },
   "VVAU_hls_7": {
     "PE": 4,
     "resType": "lut"
   },
   "Thresholding_rtl_15": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_84": {
-    "depth": 64
+    "ram_style": "auto",
+    "depth": 64,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_8": {
     "PE": 32,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_16": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_87": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_8": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_89": {
-    "depth": 4096
+    "ram_style": "block",
+    "depth": 4096,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_9": {
-    "SIMD": 4
+    "SIMD": 4,
+    "ram_style": "distributed"
   },
   "VVAU_hls_8": {
     "PE": 4,
     "resType": "lut"
   },
   "Thresholding_rtl_17": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_94": {
-    "depth": 64
+    "ram_style": "auto",
+    "depth": 64,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_9": {
     "PE": 32,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_18": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_97": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_9": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_99": {
-    "depth": 4096
+    "ram_style": "block",
+    "depth": 4096,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_10": {
-    "SIMD": 4
+    "SIMD": 4,
+    "ram_style": "distributed"
   },
   "VVAU_hls_9": {
     "PE": 4,
     "resType": "lut"
   },
   "Thresholding_rtl_19": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_104": {
-    "depth": 64
+    "ram_style": "auto",
+    "depth": 64,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_10": {
     "PE": 32,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_20": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_107": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_10": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_109": {
-    "depth": 4096
+    "ram_style": "block",
+    "depth": 4096,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_11": {
-    "SIMD": 4
+    "SIMD": 4,
+    "ram_style": "block"
   },
   "VVAU_hls_10": {
     "PE": 4,
     "resType": "lut"
   },
   "Thresholding_rtl_21": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_114": {
-    "depth": 64
+    "ram_style": "auto",
+    "depth": 64,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_11": {
     "PE": 32,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_22": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_117": {
-    "depth": 512
+    "ram_style": "block",
+    "depth": 512,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_11": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_118": {
-    "depth": 16384
+    "ram_style": "block",
+    "depth": 16384,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_12": {
-    "SIMD": 1
+    "SIMD": 1,
+    "ram_style": "block"
   },
   "VVAU_hls_11": {
     "PE": 1,
     "resType": "lut"
   },
   "Thresholding_rtl_23": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_122": {
-    "depth": 64
+    "ram_style": "auto",
+    "depth": 64,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_12": {
     "PE": 16,
     "SIMD": 8,
+    "ram_style": "auto",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_24": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_125": {
-    "depth": 1024
+    "ram_style": "block",
+    "depth": 1024,
+    "impl_style": "vivado"
   },
   "FMPadding_rtl_12": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_127": {
-    "depth": 16384
+    "ram_style": "block",
+    "depth": 16384,
+    "impl_style": "vivado"
   },
   "ConvolutionInputGenerator_rtl_13": {
-    "SIMD": 2
+    "SIMD": 2,
+    "ram_style": "block"
   },
   "VVAU_hls_12": {
     "PE": 2,
     "resType": "lut"
   },
   "Thresholding_rtl_25": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "StreamingFIFO_rtl_132": {
-    "depth": 128
+    "ram_style": "auto",
+    "depth": 128,
+    "impl_style": "rtl"
   },
   "MVAU_rtl_13": {
     "PE": 32,
     "SIMD": 8,
+    "ram_style": "block",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "Thresholding_rtl_26": {
-    "PE": 1,
-    "runtime_writeable_weights": 0
+    "PE": 1
   },
   "ConvolutionInputGenerator_rtl_14": {
-    "SIMD": 1
+    "SIMD": 1,
+    "ram_style": "block"
   },
   "Pool_hls_0": {
     "PE": 1
@@ -457,11 +555,14 @@
   "MVAU_rtl_14": {
     "PE": 1,
     "SIMD": 16,
+    "ram_style": "block",
     "resType": "dsp",
+    "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
   "ChannelwiseOp_hls_0": {
-    "PE": 1
+    "PE": 1,
+    "ram_style": "distributed"
   },
   "LabelSelect_hls_0": {
     "PE": 1

--- a/build/mobilenet-v1/folding_config/ZCU104_folding_config.json
+++ b/build/mobilenet-v1/folding_config/ZCU104_folding_config.json
@@ -4,15 +4,15 @@
     "ram_style": "ultra",
     "depth": 1024
   },
-  "ConvolutionInputGenerator_hls_0": {
+  "ConvolutionInputGenerator_rtl_0": {
     "SIMD": 1,
     "ram_style": "distributed"
   },
-  "MVAU_hls_0": {
+  "MVAU_rtl_0": {
     "PE": 16,
     "SIMD": 3,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -30,18 +30,18 @@
     "ram_style": "auto",
     "depth": 256
   },
-  "FMPadding_hls_0": {
+  "FMPadding_rtl_0": {
     "SIMD": 2
   },
   "StreamingFIFO_rtl_8": {
     "ram_style": "ultra",
     "depth": 512
   },
-  "ConvolutionInputGenerator_hls_1": {
+  "ConvolutionInputGenerator_rtl_1": {
     "SIMD": 16,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_0": {
+  "VVAU_hls_0": {
     "PE": 16,
     "resType": "lut"
   },
@@ -55,11 +55,11 @@
     "mem_mode": "internal_embedded",
     "runtime_writeable_weights": 0
   },
-  "MVAU_hls_1": {
+  "MVAU_rtl_1": {
     "PE": 8,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -73,18 +73,18 @@
     "ram_style": "auto",
     "depth": 32
   },
-  "FMPadding_hls_1": {
+  "FMPadding_rtl_1": {
     "SIMD": 4
   },
   "StreamingFIFO_rtl_19": {
     "ram_style": "ultra",
     "depth": 1024
   },
-  "ConvolutionInputGenerator_hls_2": {
+  "ConvolutionInputGenerator_rtl_2": {
     "SIMD": 8,
     "ram_style": "distributed"
   },
-  "VectorVectorActivation_hls_1": {
+  "VVAU_hls_1": {
     "PE": 8,
     "resType": "lut"
   },
@@ -98,11 +98,11 @@
     "ram_style": "auto",
     "depth": 32
   },
-  "MVAU_hls_2": {
+  "MVAU_rtl_2": {
     "PE": 16,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -116,18 +116,18 @@
     "ram_style": "auto",
     "depth": 128
   },
-  "FMPadding_hls_2": {
+  "FMPadding_rtl_2": {
     "SIMD": 2
   },
   "StreamingFIFO_rtl_29": {
     "ram_style": "ultra",
     "depth": 1024
   },
-  "ConvolutionInputGenerator_hls_3": {
+  "ConvolutionInputGenerator_rtl_3": {
     "SIMD": 16,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_2": {
+  "VVAU_hls_2": {
     "PE": 16,
     "resType": "lut"
   },
@@ -141,11 +141,11 @@
     "ram_style": "auto",
     "depth": 32
   },
-  "MVAU_hls_3": {
+  "MVAU_rtl_3": {
     "PE": 32,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -159,18 +159,18 @@
     "ram_style": "auto",
     "depth": 128
   },
-  "FMPadding_hls_3": {
+  "FMPadding_rtl_3": {
     "SIMD": 2
   },
   "StreamingFIFO_rtl_39": {
     "ram_style": "ultra",
     "depth": 4096
   },
-  "ConvolutionInputGenerator_hls_4": {
+  "ConvolutionInputGenerator_rtl_4": {
     "SIMD": 4,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_3": {
+  "VVAU_hls_3": {
     "PE": 4,
     "resType": "lut"
   },
@@ -184,11 +184,11 @@
     "ram_style": "auto",
     "depth": 32
   },
-  "MVAU_hls_4": {
+  "MVAU_rtl_4": {
     "PE": 16,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -202,18 +202,18 @@
     "ram_style": "ultra",
     "depth": 512
   },
-  "FMPadding_hls_4": {
+  "FMPadding_rtl_4": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_49": {
     "ram_style": "ultra",
     "depth": 1024
   },
-  "ConvolutionInputGenerator_hls_5": {
+  "ConvolutionInputGenerator_rtl_5": {
     "SIMD": 8,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_4": {
+  "VVAU_hls_4": {
     "PE": 8,
     "resType": "lut"
   },
@@ -227,11 +227,11 @@
     "ram_style": "auto",
     "depth": 32
   },
-  "MVAU_hls_5": {
+  "MVAU_rtl_5": {
     "PE": 32,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -245,18 +245,18 @@
     "ram_style": "ultra",
     "depth": 512
   },
-  "FMPadding_hls_5": {
+  "FMPadding_rtl_5": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_59": {
     "ram_style": "ultra",
     "depth": 8192
   },
-  "ConvolutionInputGenerator_hls_6": {
+  "ConvolutionInputGenerator_rtl_6": {
     "SIMD": 2,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_5": {
+  "VVAU_hls_5": {
     "PE": 2,
     "resType": "lut"
   },
@@ -270,11 +270,11 @@
     "ram_style": "auto",
     "depth": 32
   },
-  "MVAU_hls_6": {
+  "MVAU_rtl_6": {
     "PE": 16,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -288,18 +288,18 @@
     "ram_style": "ultra",
     "depth": 512
   },
-  "FMPadding_hls_6": {
+  "FMPadding_rtl_6": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_69": {
     "ram_style": "ultra",
     "depth": 4096
   },
-  "ConvolutionInputGenerator_hls_7": {
+  "ConvolutionInputGenerator_rtl_7": {
     "SIMD": 4,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_6": {
+  "VVAU_hls_6": {
     "PE": 4,
     "resType": "lut"
   },
@@ -313,11 +313,11 @@
     "ram_style": "auto",
     "depth": 64
   },
-  "MVAU_hls_7": {
+  "MVAU_rtl_7": {
     "PE": 32,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -331,18 +331,18 @@
     "ram_style": "ultra",
     "depth": 512
   },
-  "FMPadding_hls_7": {
+  "FMPadding_rtl_7": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_79": {
     "ram_style": "ultra",
     "depth": 4096
   },
-  "ConvolutionInputGenerator_hls_8": {
+  "ConvolutionInputGenerator_rtl_8": {
     "SIMD": 4,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_7": {
+  "VVAU_hls_7": {
     "PE": 4,
     "resType": "lut"
   },
@@ -356,11 +356,11 @@
     "ram_style": "auto",
     "depth": 64
   },
-  "MVAU_hls_8": {
+  "MVAU_rtl_8": {
     "PE": 32,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -374,18 +374,18 @@
     "ram_style": "ultra",
     "depth": 512
   },
-  "FMPadding_hls_8": {
+  "FMPadding_rtl_8": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_89": {
     "ram_style": "ultra",
     "depth": 4096
   },
-  "ConvolutionInputGenerator_hls_9": {
+  "ConvolutionInputGenerator_rtl_9": {
     "SIMD": 4,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_8": {
+  "VVAU_hls_8": {
     "PE": 4,
     "resType": "lut"
   },
@@ -399,11 +399,11 @@
     "ram_style": "auto",
     "depth": 64
   },
-  "MVAU_hls_9": {
+  "MVAU_rtl_9": {
     "PE": 32,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -417,18 +417,18 @@
     "ram_style": "ultra",
     "depth": 512
   },
-  "FMPadding_hls_9": {
+  "FMPadding_rtl_9": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_99": {
     "ram_style": "ultra",
     "depth": 4096
   },
-  "ConvolutionInputGenerator_hls_10": {
+  "ConvolutionInputGenerator_rtl_10": {
     "SIMD": 4,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_9": {
+  "VVAU_hls_9": {
     "PE": 4,
     "resType": "lut"
   },
@@ -442,11 +442,11 @@
     "ram_style": "auto",
     "depth": 64
   },
-  "MVAU_hls_10": {
+  "MVAU_rtl_10": {
     "PE": 32,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -460,18 +460,18 @@
     "ram_style": "ultra",
     "depth": 512
   },
-  "FMPadding_hls_10": {
+  "FMPadding_rtl_10": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_109": {
     "ram_style": "ultra",
     "depth": 4096
   },
-  "ConvolutionInputGenerator_hls_11": {
+  "ConvolutionInputGenerator_rtl_11": {
     "SIMD": 4,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_10": {
+  "VVAU_hls_10": {
     "PE": 4,
     "resType": "lut"
   },
@@ -485,11 +485,11 @@
     "ram_style": "auto",
     "depth": 64
   },
-  "MVAU_hls_11": {
+  "MVAU_rtl_11": {
     "PE": 32,
     "SIMD": 8,
     "ram_style": "auto",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 0
   },
@@ -503,18 +503,18 @@
     "ram_style": "ultra",
     "depth": 512
   },
-  "FMPadding_hls_11": {
+  "FMPadding_rtl_11": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_118": {
     "ram_style": "ultra",
     "depth": 16384
   },
-  "ConvolutionInputGenerator_hls_12": {
+  "ConvolutionInputGenerator_rtl_12": {
     "SIMD": 1,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_11": {
+  "VVAU_hls_11": {
     "PE": 1,
     "resType": "lut"
   },
@@ -528,11 +528,11 @@
     "ram_style": "auto",
     "depth": 64
   },
-  "MVAU_hls_12": {
+  "MVAU_rtl_12": {
     "PE": 16,
     "SIMD": 8,
     "ram_style": "ultra",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 1
   },
@@ -546,18 +546,18 @@
     "ram_style": "ultra",
     "depth": 1024
   },
-  "FMPadding_hls_12": {
+  "FMPadding_rtl_12": {
     "SIMD": 1
   },
   "StreamingFIFO_rtl_127": {
     "ram_style": "ultra",
     "depth": 16384
   },
-  "ConvolutionInputGenerator_hls_13": {
+  "ConvolutionInputGenerator_rtl_13": {
     "SIMD": 2,
     "ram_style": "block"
   },
-  "VectorVectorActivation_hls_12": {
+  "VVAU_hls_12": {
     "PE": 2,
     "resType": "lut"
   },
@@ -571,11 +571,11 @@
     "ram_style": "auto",
     "depth": 128
   },
-  "MVAU_hls_13": {
+  "MVAU_rtl_13": {
     "PE": 32,
     "SIMD": 8,
     "ram_style": "ultra",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 1
   },
@@ -585,18 +585,18 @@
     "mem_mode": "internal_embedded",
     "runtime_writeable_weights": 0
   },
-  "ConvolutionInputGenerator_hls_14": {
+  "ConvolutionInputGenerator_rtl_14": {
     "SIMD": 1,
     "ram_style": "block"
   },
   "Pool_hls_0": {
     "PE": 1
   },
-  "MVAU_hls_14": {
+  "MVAU_rtl_14": {
     "PE": 1,
     "SIMD": 16,
     "ram_style": "ultra",
-    "resType": "lut",
+    "resType": "dsp",
     "mem_mode": "internal_decoupled",
     "runtime_writeable_weights": 1
   },

--- a/build/mobilenet-v1/specialize_layers_config/U200_specialize_layers_config.json
+++ b/build/mobilenet-v1/specialize_layers_config/U200_specialize_layers_config.json
@@ -1,0 +1,180 @@
+{
+    "Defaults": {},
+    "ConvolutionInputGenerator_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "MVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_13": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_13": {
+      "preferred_impl_style": "hls"
+    },
+    "ConvolutionInputGenerator_14": {
+      "preferred_impl_style": "rtl"
+    },
+    "Pool_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_14": {
+      "preferred_impl_style": "hls"
+    },
+    "ChannelwiseOp_0": {
+      "preferred_impl_style": "hls"
+    },
+    "LabelSelect_0": {
+      "preferred_impl_style": "hls"
+    }
+  }

--- a/build/mobilenet-v1/specialize_layers_config/U250_specialize_layers_config.json
+++ b/build/mobilenet-v1/specialize_layers_config/U250_specialize_layers_config.json
@@ -1,0 +1,180 @@
+{
+    "Defaults": {},
+    "ConvolutionInputGenerator_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "MVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_13": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_13": {
+      "preferred_impl_style": "hls"
+    },
+    "ConvolutionInputGenerator_14": {
+      "preferred_impl_style": "rtl"
+    },
+    "Pool_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_14": {
+      "preferred_impl_style": "hls"
+    },
+    "ChannelwiseOp_0": {
+      "preferred_impl_style": "hls"
+    },
+    "LabelSelect_0": {
+      "preferred_impl_style": "hls"
+    }
+  }

--- a/build/mobilenet-v1/specialize_layers_config/U280_specialize_layers_config.json
+++ b/build/mobilenet-v1/specialize_layers_config/U280_specialize_layers_config.json
@@ -1,0 +1,180 @@
+{
+    "Defaults": {},
+    "ConvolutionInputGenerator_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "MVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_13": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_13": {
+      "preferred_impl_style": "hls"
+    },
+    "ConvolutionInputGenerator_14": {
+      "preferred_impl_style": "rtl"
+    },
+    "Pool_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_14": {
+      "preferred_impl_style": "hls"
+    },
+    "ChannelwiseOp_0": {
+      "preferred_impl_style": "hls"
+    },
+    "LabelSelect_0": {
+      "preferred_impl_style": "hls"
+    }
+  }

--- a/build/mobilenet-v1/specialize_layers_config/U50_specialize_layers_config.json
+++ b/build/mobilenet-v1/specialize_layers_config/U50_specialize_layers_config.json
@@ -1,0 +1,180 @@
+{
+    "Defaults": {},
+    "ConvolutionInputGenerator_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "MVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_13": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_13": {
+      "preferred_impl_style": "hls"
+    },
+    "ConvolutionInputGenerator_14": {
+      "preferred_impl_style": "rtl"
+    },
+    "Pool_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_14": {
+      "preferred_impl_style": "hls"
+    },
+    "ChannelwiseOp_0": {
+      "preferred_impl_style": "hls"
+    },
+    "LabelSelect_0": {
+      "preferred_impl_style": "hls"
+    }
+  }

--- a/build/mobilenet-v1/specialize_layers_config/ZCU102_specialize_layers_config.json
+++ b/build/mobilenet-v1/specialize_layers_config/ZCU102_specialize_layers_config.json
@@ -16,7 +16,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_0": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_1": {
       "preferred_impl_style": "rtl"
@@ -34,7 +34,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_1": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_3": {
       "preferred_impl_style": "rtl"
@@ -52,7 +52,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_2": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_5": {
       "preferred_impl_style": "rtl"
@@ -70,7 +70,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_3": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_7": {
       "preferred_impl_style": "rtl"
@@ -88,7 +88,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_4": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_9": {
       "preferred_impl_style": "rtl"
@@ -106,7 +106,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_5": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_11": {
       "preferred_impl_style": "rtl"
@@ -124,7 +124,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_6": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_13": {
       "preferred_impl_style": "rtl"
@@ -142,7 +142,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_7": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_15": {
       "preferred_impl_style": "rtl"
@@ -160,7 +160,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_8": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_17": {
       "preferred_impl_style": "rtl"
@@ -178,7 +178,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_9": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_19": {
       "preferred_impl_style": "rtl"
@@ -196,7 +196,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_10": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_21": {
       "preferred_impl_style": "rtl"
@@ -214,7 +214,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_11": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_23": {
       "preferred_impl_style": "rtl"
@@ -232,7 +232,7 @@
       "preferred_impl_style": "rtl"
     },
     "VVAU_12": {
-      "preferred_impl_style": "rtl"
+      "preferred_impl_style": "hls"
     },
     "Thresholding_25": {
       "preferred_impl_style": "rtl"

--- a/build/mobilenet-v1/specialize_layers_config/ZCU104_specialize_layers_config.json
+++ b/build/mobilenet-v1/specialize_layers_config/ZCU104_specialize_layers_config.json
@@ -1,0 +1,261 @@
+{
+    "Defaults": {},
+    "ConvolutionInputGenerator_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "MVAU_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_0": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_0": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_0": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_1": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_2": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_1": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_1": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_3": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_4": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_2": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_2": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_5": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_6": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_3": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_3": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_7": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_8": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_4": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_4": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_9": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_10": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_5": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_5": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_11": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_12": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_6": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_6": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_13": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_14": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_7": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_7": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_15": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_16": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_8": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_8": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_17": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_18": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_9": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_9": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_19": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_20": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_10": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_10": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_21": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_22": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_11": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_11": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_23": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_24": {
+      "preferred_impl_style": "hls"
+    },
+    "FMPadding_12": {
+      "preferred_impl_style": "rtl"
+    },
+    "ConvolutionInputGenerator_13": {
+      "preferred_impl_style": "rtl"
+    },
+    "VVAU_12": {
+      "preferred_impl_style": "hls"
+    },
+    "Thresholding_25": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_13": {
+      "preferred_impl_style": "rtl"
+    },
+    "Thresholding_26": {
+      "preferred_impl_style": "hls"
+    },
+    "ConvolutionInputGenerator_14": {
+      "preferred_impl_style": "rtl"
+    },
+    "Pool_0": {
+      "preferred_impl_style": "hls"
+    },
+    "MVAU_14": {
+      "preferred_impl_style": "rtl"
+    },
+    "ChannelwiseOp_0": {
+      "preferred_impl_style": "hls"
+    },
+    "LabelSelect_0": {
+      "preferred_impl_style": "hls"
+    }
+  }


### PR DESCRIPTION
This PR will update the MobileNet-v1 build flows by adding a specialize_layers configuration per board and update folding configuration & flow steps to work with latest FINN release (v0.10)
- [x] Update ZCU102 flow
- [x] Update ZCU104 flow
- [x] Update U50 flow
- [x] Update U200 flow
- [x] Update U280 flow
- [x] Update U250 flow
- [ ] Test ZCU104 & U250 bitfiles with notebooks on board 