### PR TITLE
Soften constraint on numpy version for Pynq-Z1 and Pynq-Z2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     install_requires=[
         "pynq>=2.5.1",
         "bitstring>=3.1.7",
-        "numpy==1.24.1",
+        "numpy<=1.24.1",
         "finn-dataset_loading==0.0.5",  # noqa
     ],
     extras_require={


### PR DESCRIPTION
Allow lower versions for numpy, to enable installation on Pynq-Z1 and Pynq-Z2 boards.