### PR TITLE
Use numpy less than 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     install_requires=[
         "pynq>=2.5.1",
         "bitstring>=3.1.7",
-        "numpy<=1.24.1",
+        "numpy<=2.0",
         "finn-dataset_loading==0.0.5",  # noqa
     ],
     extras_require={


### PR DESCRIPTION
This will avoid updating pynq on 3.1 images