### PR TITLE
FINN examples on AUP-ZU3

### DIFF
--- a/build/bnn-pynq/build.py
+++ b/build/bnn-pynq/build.py
@@ -47,8 +47,8 @@ models = [
 verif_en = os.getenv("VERIFICATION_EN", "0")
 
 # which platforms to build the networks for
-zynq_platforms = ["Pynq-Z1", "Ultra96", "ZCU104"]
-alveo_platforms = ["U250"]
+zynq_platforms = ["AUP-ZU3_8GB"] #["Pynq-Z1", "Ultra96", "ZCU104"]
+alveo_platforms = [] #["U250"]
 platforms_to_build = zynq_platforms + alveo_platforms
 
 
@@ -84,11 +84,13 @@ for platform_name in platforms_to_build:
         cfg = build_cfg.DataflowBuildConfig(
             output_dir="output_%s_%s" % (model_name, release_platform_name),
             folding_config_file="folding_config/%s_folding_config.json" % model_name,
+            mvau_wwidth_max=1000,
             synth_clk_period_ns=5.0,
             board=platform_name,
             shell_flow_type=shell_flow_type,
             vitis_platform=vitis_platform,
             generate_outputs=[
+                build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
                 build_cfg.DataflowOutputType.BITFILE,
                 build_cfg.DataflowOutputType.STITCHED_IP,
             ],

--- a/build/bnn-pynq/folding_config/cnv-w1a1_folding_config.json
+++ b/build/bnn-pynq/folding_config/cnv-w1a1_folding_config.json
@@ -9,37 +9,34 @@
   },
   "MVAU_hls_0": {
     "PE": 16,
-    "SIMD": 3,
+    "SIMD": 27,
     "ram_style": "auto",
     "resType": "lut"
   },
   "ConvolutionInputGenerator_rtl_1": {
-    "SIMD": 32,
+    "SIMD": 64,
     "ram_style": "distributed"
   },
   "MVAU_hls_1": {
-    "PE": 32,
-    "SIMD": 32,
+    "PE": 16,
+    "SIMD": 576,
     "ram_style": "auto",
     "resType": "lut"
   },
   "ConvolutionInputGenerator_rtl_2": {
-    "SIMD": 32,
+    "SIMD": 16,
     "ram_style": "distributed"
   },
-  "MVAU_hls_2": {
-    "PE": 16,
-    "SIMD": 32,
-    "ram_style": "auto",
-    "resType": "lut"
+  "Pool_hls_0": {
+    "PE": 16
   },
   "ConvolutionInputGenerator_rtl_3": {
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "MVAU_hls_3": {
-    "PE": 16,
-    "SIMD": 32,
+  "MVAU_hls_2": {
+    "PE": 4,
+    "SIMD": 576,
     "ram_style": "auto",
     "resType": "lut"
   },
@@ -47,37 +44,54 @@
     "SIMD": 32,
     "ram_style": "distributed"
   },
-  "MVAU_hls_4": {
-    "PE": 4,
-    "SIMD": 32,
+  "MVAU_hls_3": {
+    "PE": 8,
+    "SIMD": 576,
     "ram_style": "auto",
     "resType": "lut"
   },
   "ConvolutionInputGenerator_rtl_5": {
-    "SIMD": 32,
+    "SIMD": 4,
+    "ram_style": "distributed"
+  },
+  "Pool_hls_1": {
+    "PE": 4
+  },
+  "ConvolutionInputGenerator_rtl_6": {
+    "SIMD": 4,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_4": {
+    "PE": 1,
+    "SIMD": 576,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "ConvolutionInputGenerator_rtl_7": {
+    "SIMD": 1,
     "ram_style": "distributed"
   },
   "MVAU_hls_5": {
     "PE": 1,
-    "SIMD": 32,
+    "SIMD": 128,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_6": {
     "PE": 1,
-    "SIMD": 4,
+    "SIMD": 32,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_7": {
     "PE": 1,
-    "SIMD": 8,
+    "SIMD": 64,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_8": {
-    "PE": 5,
-    "SIMD": 1,
+    "PE": 1,
+    "SIMD": 2,
     "ram_style": "auto",
     "resType": "lut"
   },

--- a/build/bnn-pynq/folding_config/cnv-w1a2_folding_config.json
+++ b/build/bnn-pynq/folding_config/cnv-w1a2_folding_config.json
@@ -4,12 +4,12 @@
     "PE": 1
   },
   "ConvolutionInputGenerator_rtl_0": {
-    "SIMD": 3,
+    "SIMD": 1,
     "ram_style": "distributed"
   },
   "MVAU_hls_0": {
-    "PE": 8,
-    "SIMD": 3,
+    "PE": 2,
+    "SIMD": 27,
     "ram_style": "auto",
     "resType": "lut"
   },
@@ -18,67 +18,81 @@
     "ram_style": "distributed"
   },
   "MVAU_hls_1": {
-    "PE": 16,
-    "SIMD": 16,
+    "PE": 2,
+    "SIMD": 576,
     "ram_style": "auto",
     "resType": "lut"
   },
   "ConvolutionInputGenerator_rtl_2": {
-    "SIMD": 16,
+    "SIMD": 2,
+    "ram_style": "distributed"
+  },
+  "Pool_hls_0": {
+    "PE": 2
+  },
+  "ConvolutionInputGenerator_rtl_3": {
+    "SIMD": 4,
     "ram_style": "distributed"
   },
   "MVAU_hls_2": {
-    "PE": 8,
-    "SIMD": 16,
+    "PE": 1,
+    "SIMD": 576,
     "ram_style": "auto",
     "resType": "lut"
   },
-  "ConvolutionInputGenerator_rtl_3": {
-    "SIMD": 16,
+  "ConvolutionInputGenerator_rtl_4": {
+    "SIMD": 4,
     "ram_style": "distributed"
   },
   "MVAU_hls_3": {
-    "PE": 8,
-    "SIMD": 16,
-    "ram_style": "block",
-    "resType": "lut"
-  },
-  "ConvolutionInputGenerator_rtl_4": {
-    "SIMD": 8,
-    "ram_style": "distributed"
-  },
-  "MVAU_hls_4": {
-    "PE": 4,
-    "SIMD": 8,
+    "PE": 1,
+    "SIMD": 576,
     "ram_style": "auto",
     "resType": "lut"
   },
   "ConvolutionInputGenerator_rtl_5": {
-    "SIMD": 8,
+    "SIMD": 1,
+    "ram_style": "distributed"
+  },
+  "Pool_hls_1": {
+    "PE": 1
+  },
+  "ConvolutionInputGenerator_rtl_6": {
+    "SIMD": 1,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_4": {
+    "PE": 1,
+    "SIMD": 96,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "ConvolutionInputGenerator_rtl_7": {
+    "SIMD": 1,
     "ram_style": "distributed"
   },
   "MVAU_hls_5": {
     "PE": 1,
-    "SIMD": 8,
+    "SIMD": 18,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_6": {
     "PE": 1,
-    "SIMD": 2,
-    "ram_style": "distributed",
+    "SIMD": 4,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_7": {
-    "PE": 2,
-    "SIMD": 2,
-    "ram_style": "block",
+    "PE": 1,
+    "SIMD": 8,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_8": {
-    "PE": 5,
+    "PE": 1,
     "SIMD": 1,
-    "ram_style": "distributed",
+    "ram_style": "auto",
     "resType": "lut"
   },
   "LabelSelect_hls_0": {

--- a/build/bnn-pynq/folding_config/cnv-w2a2_folding_config.json
+++ b/build/bnn-pynq/folding_config/cnv-w2a2_folding_config.json
@@ -4,12 +4,12 @@
     "PE": 1
   },
   "ConvolutionInputGenerator_rtl_0": {
-    "SIMD": 3,
+    "SIMD": 1,
     "ram_style": "distributed"
   },
   "MVAU_hls_0": {
-    "PE": 8,
-    "SIMD": 3,
+    "PE": 2,
+    "SIMD": 27,
     "ram_style": "auto",
     "resType": "lut"
   },
@@ -18,67 +18,81 @@
     "ram_style": "distributed"
   },
   "MVAU_hls_1": {
-    "PE": 16,
-    "SIMD": 16,
+    "PE": 4,
+    "SIMD": 288,
     "ram_style": "auto",
     "resType": "lut"
   },
   "ConvolutionInputGenerator_rtl_2": {
-    "SIMD": 16,
+    "SIMD": 2,
+    "ram_style": "distributed"
+  },
+  "Pool_hls_0": {
+    "PE": 2
+  },
+  "ConvolutionInputGenerator_rtl_3": {
+    "SIMD": 4,
     "ram_style": "distributed"
   },
   "MVAU_hls_2": {
-    "PE": 8,
-    "SIMD": 16,
+    "PE": 1,
+    "SIMD": 576,
     "ram_style": "auto",
     "resType": "lut"
   },
-  "ConvolutionInputGenerator_rtl_3": {
-    "SIMD": 16,
+  "ConvolutionInputGenerator_rtl_4": {
+    "SIMD": 4,
     "ram_style": "distributed"
   },
   "MVAU_hls_3": {
-    "PE": 8,
-    "SIMD": 16,
-    "ram_style": "block",
-    "resType": "lut"
-  },
-  "ConvolutionInputGenerator_rtl_4": {
-    "SIMD": 8,
-    "ram_style": "distributed"
-  },
-  "MVAU_hls_4": {
-    "PE": 4,
-    "SIMD": 8,
+    "PE": 1,
+    "SIMD": 576,
     "ram_style": "auto",
     "resType": "lut"
   },
   "ConvolutionInputGenerator_rtl_5": {
-    "SIMD": 8,
+    "SIMD": 1,
+    "ram_style": "distributed"
+  },
+  "Pool_hls_1": {
+    "PE": 1
+  },
+  "ConvolutionInputGenerator_rtl_6": {
+    "SIMD": 1,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_4": {
+    "PE": 1,
+    "SIMD": 96,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "ConvolutionInputGenerator_rtl_7": {
+    "SIMD": 1,
     "ram_style": "distributed"
   },
   "MVAU_hls_5": {
     "PE": 1,
-    "SIMD": 8,
+    "SIMD": 18,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_6": {
     "PE": 1,
-    "SIMD": 2,
-    "ram_style": "distributed",
+    "SIMD": 4,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_7": {
-    "PE": 2,
-    "SIMD": 2,
-    "ram_style": "block",
+    "PE": 1,
+    "SIMD": 8,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_8": {
-    "PE": 5,
+    "PE": 1,
     "SIMD": 1,
-    "ram_style": "distributed",
+    "ram_style": "auto",
     "resType": "lut"
   },
   "LabelSelect_hls_0": {

--- a/build/bnn-pynq/folding_config/tfc-w1a1_folding_config.json
+++ b/build/bnn-pynq/folding_config/tfc-w1a1_folding_config.json
@@ -1,33 +1,33 @@
 {
   "Defaults": {},
   "Thresholding_rtl_0": {
-    "PE": 49
+    "PE": 392
   },
   "MVAU_hls_0": {
-    "PE": 16,
-    "SIMD": 49,
-    "ram_style": "block",
+    "PE": 32,
+    "SIMD": 784,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_1": {
-    "PE": 8,
-    "SIMD": 8,
+    "PE": 32,
+    "SIMD": 64,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_2": {
-    "PE": 8,
-    "SIMD": 8,
+    "PE": 32,
+    "SIMD": 64,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_3": {
-    "PE": 10,
-    "SIMD": 8,
-    "ram_style": "distributed",
+    "PE": 5,
+    "SIMD": 64,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "LabelSelect_hls_0": {
-    "PE": 1
+    "PE": 5
   }
 }

--- a/build/bnn-pynq/folding_config/tfc-w1a2_folding_config.json
+++ b/build/bnn-pynq/folding_config/tfc-w1a2_folding_config.json
@@ -1,33 +1,33 @@
 {
   "Defaults": {},
   "Thresholding_rtl_0": {
-    "PE": 49
+    "PE": 98
   },
   "MVAU_hls_0": {
-    "PE": 16,
-    "SIMD": 49,
-    "ram_style": "block",
+    "PE": 8,
+    "SIMD": 784,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_1": {
     "PE": 8,
-    "SIMD": 8,
+    "SIMD": 64,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_2": {
     "PE": 8,
-    "SIMD": 8,
+    "SIMD": 64,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_3": {
-    "PE": 10,
-    "SIMD": 8,
-    "ram_style": "distributed",
+    "PE": 2,
+    "SIMD": 64,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "LabelSelect_hls_0": {
-    "PE": 1
+    "PE": 2
   }
 }

--- a/build/bnn-pynq/folding_config/tfc-w2a2_folding_config.json
+++ b/build/bnn-pynq/folding_config/tfc-w2a2_folding_config.json
@@ -1,33 +1,33 @@
 {
   "Defaults": {},
   "Thresholding_rtl_0": {
-    "PE": 49
+    "PE": 98
   },
   "MVAU_hls_0": {
     "PE": 16,
-    "SIMD": 49,
-    "ram_style": "block",
+    "SIMD": 392,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_1": {
     "PE": 8,
-    "SIMD": 8,
+    "SIMD": 64,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_2": {
     "PE": 8,
-    "SIMD": 8,
+    "SIMD": 64,
     "ram_style": "auto",
     "resType": "lut"
   },
   "MVAU_hls_3": {
-    "PE": 10,
-    "SIMD": 8,
-    "ram_style": "distributed",
+    "PE": 2,
+    "SIMD": 64,
+    "ram_style": "auto",
     "resType": "lut"
   },
   "LabelSelect_hls_0": {
-    "PE": 1
+    "PE": 2
   }
 }

--- a/build/bnn-pynq/specialize_layers_config/cnv-w1a1_specialize_layers.json
+++ b/build/bnn-pynq/specialize_layers_config/cnv-w1a1_specialize_layers.json
@@ -7,52 +7,67 @@
     "preferred_impl_style": "rtl"
   },
   "MVAU_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_1": {
     "preferred_impl_style": "rtl"
   },
   "MVAU_1": {
-    "preferred_impl_style": "hls"
-  },
-  "StreamingMaxPool_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_2": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_2": {
-    "preferred_impl_style": "hls"
+  "Pool_0": {
+    "preferred_impl_style": "rtl"
   },
   "ConvolutionInputGenerator_3": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_3": {
-    "preferred_impl_style": "hls"
-  },
-  "StreamingMaxPool_1": {
-    "preferred_impl_style": "hls"
+  "MVAU_2": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_4": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_4": {
-    "preferred_impl_style": "hls"
+  "MVAU_3": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_5": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_5": {
+  "Pool_1": {
+    "preferred_impl_style": "rtl"
+  },
+  "ConvolutionInputGenerator_rtl6": {
     "preferred_impl_style": "hls"
+  },
+  "MVAU_4": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
+  },
+  "ConvolutionInputGenerator_7": {
+    "preferred_impl_style": "rtl"
+  },
+  "MVAU_5": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_6": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_7": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_8": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "LabelSelect_0": {
     "preferred_impl_style": "hls"

--- a/build/bnn-pynq/specialize_layers_config/cnv-w1a2_specialize_layers.json
+++ b/build/bnn-pynq/specialize_layers_config/cnv-w1a2_specialize_layers.json
@@ -7,52 +7,67 @@
     "preferred_impl_style": "rtl"
   },
   "MVAU_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_1": {
     "preferred_impl_style": "rtl"
   },
   "MVAU_1": {
-    "preferred_impl_style": "hls"
-  },
-  "StreamingMaxPool_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_2": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_2": {
+  "Pool_0": {
     "preferred_impl_style": "hls"
   },
   "ConvolutionInputGenerator_3": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_3": {
-    "preferred_impl_style": "hls"
-  },
-  "StreamingMaxPool_1": {
-    "preferred_impl_style": "hls"
+  "MVAU_2": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_4": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_4": {
-    "preferred_impl_style": "hls"
+  "MVAU_3": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_5": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_5": {
+  "Pool_1": {
     "preferred_impl_style": "hls"
+  },
+  "ConvolutionInputGenerator_6": {
+    "preferred_impl_style": "rtl"
+  },
+  "MVAU_4": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
+  },
+  "ConvolutionInputGenerator_7": {
+    "preferred_impl_style": "rtl"
+  },
+  "MVAU_5": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_6": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_7": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_8": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "LabelSelect_0": {
     "preferred_impl_style": "hls"

--- a/build/bnn-pynq/specialize_layers_config/cnv-w2a2_specialize_layers.json
+++ b/build/bnn-pynq/specialize_layers_config/cnv-w2a2_specialize_layers.json
@@ -7,52 +7,67 @@
     "preferred_impl_style": "rtl"
   },
   "MVAU_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_1": {
     "preferred_impl_style": "rtl"
   },
   "MVAU_1": {
-    "preferred_impl_style": "hls"
-  },
-  "StreamingMaxPool_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_2": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_2": {
+  "Pool_0": {
     "preferred_impl_style": "hls"
   },
   "ConvolutionInputGenerator_3": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_3": {
-    "preferred_impl_style": "hls"
-  },
-  "StreamingMaxPool_1": {
-    "preferred_impl_style": "hls"
+  "MVAU_2": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_4": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_4": {
-    "preferred_impl_style": "hls"
+  "MVAU_3": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "ConvolutionInputGenerator_5": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_5": {
+  "Pool_1": {
     "preferred_impl_style": "hls"
+  },
+  "ConvolutionInputGenerator_6": {
+    "preferred_impl_style": "rtl"
+  },
+  "MVAU_4": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
+  },
+  "ConvolutionInputGenerator_7": {
+    "preferred_impl_style": "rtl"
+  },
+  "MVAU_5": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_6": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_7": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_8": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "LabelSelect_0": {
     "preferred_impl_style": "hls"

--- a/build/bnn-pynq/specialize_layers_config/tfc-w1a1_specialize_layers.json
+++ b/build/bnn-pynq/specialize_layers_config/tfc-w1a1_specialize_layers.json
@@ -4,16 +4,20 @@
     "preferred_impl_style": "rtl"
   },
   "MVAU_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_1": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_2": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_3": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "LabelSelect_0": {
     "preferred_impl_style": "hls"

--- a/build/bnn-pynq/specialize_layers_config/tfc-w1a2_specialize_layers.json
+++ b/build/bnn-pynq/specialize_layers_config/tfc-w1a2_specialize_layers.json
@@ -4,16 +4,20 @@
     "preferred_impl_style": "rtl"
   },
   "MVAU_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_1": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_2": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_3": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "LabelSelect_0": {
     "preferred_impl_style": "hls"

--- a/build/bnn-pynq/specialize_layers_config/tfc-w2a2_specialize_layers.json
+++ b/build/bnn-pynq/specialize_layers_config/tfc-w2a2_specialize_layers.json
@@ -4,16 +4,20 @@
     "preferred_impl_style": "rtl"
   },
   "MVAU_0": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_1": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_2": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "MVAU_3": {
-    "preferred_impl_style": "hls"
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
   },
   "LabelSelect_0": {
     "preferred_impl_style": "hls"

--- a/build/cybersecurity-mlp/build.py
+++ b/build/cybersecurity-mlp/build.py
@@ -38,7 +38,7 @@ model_name = "unsw_nb15-mlp-w2a2"
 verif_en = os.getenv("VERIFICATION_EN", "0")
 
 # Which platforms to build the networks for
-zynq_platforms = ["Pynq-Z1", "Ultra96", "ZCU104"]
+zynq_platforms = ["AUP-ZU3_8GB"] #["Pynq-Z1", "Ultra96", "ZCU104"]
 alveo_platforms = []
 
 # Note: only zynq platforms currently tested
@@ -75,18 +75,16 @@ for platform_name in platforms_to_build:
     # Set up the build configuration for this model
     cfg = build_cfg.DataflowBuildConfig(
         output_dir="output_%s_%s" % (model_name, release_platform_name),
-        mvau_wwidth_max=80,
-        target_fps=1000000,
+        folding_config_file="folding_config/cybsec_folding_config.json",
         synth_clk_period_ns=10.0,
         board=platform_name,
         shell_flow_type=shell_flow_type,
         vitis_platform=vitis_platform,
         vitis_opt_strategy=build_cfg.VitisOptStrategyCfg.PERFORMANCE_BEST,
+        specialize_layers_config_file="specialize_layers_config/cybersecurity_specialize_layers.json",
         generate_outputs=[
-            build_cfg.DataflowOutputType.PYNQ_DRIVER,
             build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
             build_cfg.DataflowOutputType.BITFILE,
-            build_cfg.DataflowOutputType.DEPLOYMENT_PACKAGE,
             build_cfg.DataflowOutputType.STITCHED_IP,
         ],
     )

--- a/build/cybersecurity-mlp/folding_config/cybsec_folding_config.json
+++ b/build/cybersecurity-mlp/folding_config/cybsec_folding_config.json
@@ -1,0 +1,27 @@
+{
+  "Defaults": {},
+  "MVAU_hls_0": {
+    "PE": 64,
+    "SIMD": 600,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "MVAU_hls_1": {
+    "PE": 64,
+    "SIMD": 64,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "MVAU_hls_2": {
+    "PE": 64,
+    "SIMD": 64,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "MVAU_hls_3": {
+    "PE": 1,
+    "SIMD": 64,
+    "ram_style": "auto",
+    "resType": "lut"
+  }
+}

--- a/build/cybersecurity-mlp/specialize_layers_config/cybersecurity_specialize_layers.json
+++ b/build/cybersecurity-mlp/specialize_layers_config/cybersecurity_specialize_layers.json
@@ -1,0 +1,19 @@
+{
+  "Defaults": {},
+  "MVAU_0": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
+  },
+  "MVAU_1": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
+  },
+  "MVAU_2": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
+  },
+  "MVAU_3": {
+    "preferred_impl_style": "hls",
+    "mem_mode": "internal_embedded"
+  }
+}

--- a/build/get-finn.sh
+++ b/build/get-finn.sh
@@ -31,7 +31,7 @@
 # URL for git repo to be cloned
 REPO_URL=https://github.com/Xilinx/finn
 # commit hash for repo
-REPO_COMMIT=274785308d563cf2c8d899023b3b098cf430f4bf
+REPO_COMMIT=3a0cd1c5ae850e4564521cd00414860202d327da
 # directory (under the same folder as this script) to clone to
 REPO_DIR=finn
 

--- a/build/gtsrb/build.py
+++ b/build/gtsrb/build.py
@@ -44,7 +44,7 @@ model_file = "models/%s.onnx" % model_name
 verif_en = os.getenv("VERIFICATION_EN", "0")
 
 # which platforms to build the networks for
-zynq_platforms = ["Pynq-Z1"]
+zynq_platforms = ["AUP-ZU3_8GB"] #["Pynq-Z1"]
 alveo_platforms = []
 platforms_to_build = zynq_platforms + alveo_platforms
 
@@ -113,21 +113,18 @@ for platform_name in platforms_to_build:
     # set up the build configuration for this model
     cfg = build_cfg.DataflowBuildConfig(
         output_dir="output_%s_%s" % (model_name, release_platform_name),
-        target_fps=3000,
+        folding_config_file="folding_config/gtsrb_folding_config.json",
+        mvau_wwidth_max=1000,
         synth_clk_period_ns=10.0,
         board=platform_name,
         steps=custom_build_steps,
-        folding_config_file="folding_config/gtsrb_folding_config.json",
         specialize_layers_config_file="specialize_layers_config/gtsrb_specialize_layers.json",
         shell_flow_type=shell_flow_type,
         vitis_platform=vitis_platform,
         generate_outputs=[
             build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
             build_cfg.DataflowOutputType.STITCHED_IP,
-            build_cfg.DataflowOutputType.RTLSIM_PERFORMANCE,
             build_cfg.DataflowOutputType.BITFILE,
-            build_cfg.DataflowOutputType.DEPLOYMENT_PACKAGE,
-            build_cfg.DataflowOutputType.PYNQ_DRIVER,
         ],
     )
     # launch FINN compiler to build

--- a/build/gtsrb/folding_config/gtsrb_folding_config.json
+++ b/build/gtsrb/folding_config/gtsrb_folding_config.json
@@ -1,87 +1,101 @@
 {
-    "Defaults": {},
-    "Thresholding_rtl_0": {
-      "PE": 1
-    },
-    "ConvolutionInputGenerator_rtl_0": {
-      "SIMD": 3,
-      "ram_style": "distributed"
-    },
-    "MVAU_hls_0": {
-      "PE": 16,
-      "SIMD": 3,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "ConvolutionInputGenerator_rtl_1": {
-      "SIMD": 32,
-      "ram_style": "distributed"
-    },
-    "MVAU_hls_1": {
-      "PE": 32,
-      "SIMD": 32,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "ConvolutionInputGenerator_rtl_2": {
-      "SIMD": 32,
-      "ram_style": "distributed"
-    },
-    "MVAU_hls_2": {
-      "PE": 16,
-      "SIMD": 32,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "ConvolutionInputGenerator_rtl_3": {
-      "SIMD": 32,
-      "ram_style": "distributed"
-    },
-    "MVAU_hls_3": {
-      "PE": 16,
-      "SIMD": 32,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "ConvolutionInputGenerator_rtl_4": {
-      "SIMD": 32,
-      "ram_style": "distributed"
-    },
-    "MVAU_hls_4": {
-      "PE": 4,
-      "SIMD": 32,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "ConvolutionInputGenerator_rtl_5": {
-      "SIMD": 32,
-      "ram_style": "distributed"
-    },
-    "MVAU_hls_5": {
-      "PE": 1,
-      "SIMD": 32,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "MVAU_hls_6": {
-      "PE": 1,
-      "SIMD": 4,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "MVAU_hls_7": {
-      "PE": 1,
-      "SIMD": 8,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "MVAU_hls_8": {
-      "PE": 4,
-      "SIMD": 1,
-      "ram_style": "auto",
-      "resType": "lut"
-    },
-    "LabelSelect_hls_0": {
-      "PE": 1
-    }
+  "Defaults": {},
+  "Thresholding_rtl_0": {
+    "PE": 1
+  },
+  "ConvolutionInputGenerator_rtl_0": {
+    "SIMD": 3,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_0": {
+    "PE": 8,
+    "SIMD": 27,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "ConvolutionInputGenerator_rtl_1": {
+    "SIMD": 64,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_1": {
+    "PE": 8,
+    "SIMD": 576,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "ConvolutionInputGenerator_rtl_2": {
+    "SIMD": 8,
+    "ram_style": "distributed"
+  },
+  "Pool_hls_0": {
+    "PE": 8
+  },
+  "ConvolutionInputGenerator_rtl_3": {
+    "SIMD": 8,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_2": {
+    "PE": 2,
+    "SIMD": 576,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "ConvolutionInputGenerator_rtl_4": {
+    "SIMD": 16,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_3": {
+    "PE": 4,
+    "SIMD": 576,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "ConvolutionInputGenerator_rtl_5": {
+    "SIMD": 2,
+    "ram_style": "distributed"
+  },
+  "Pool_hls_1": {
+    "PE": 2
+  },
+  "ConvolutionInputGenerator_rtl_6": {
+    "SIMD": 1,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_4": {
+    "PE": 1,
+    "SIMD": 288,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "ConvolutionInputGenerator_rtl_7": {
+    "SIMD": 1,
+    "ram_style": "distributed"
+  },
+  "MVAU_hls_5": {
+    "PE": 1,
+    "SIMD": 48,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "MVAU_hls_6": {
+    "PE": 1,
+    "SIMD": 16,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "MVAU_hls_7": {
+    "PE": 1,
+    "SIMD": 32,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "MVAU_hls_8": {
+    "PE": 1,
+    "SIMD": 2,
+    "ram_style": "auto",
+    "resType": "lut"
+  },
+  "LabelSelect_hls_0": {
+    "PE": 1
+  }
 }

--- a/build/gtsrb/specialize_layers_config/gtsrb_specialize_layers.json
+++ b/build/gtsrb/specialize_layers_config/gtsrb_specialize_layers.json
@@ -15,31 +15,37 @@
   "MVAU_1": {
     "preferred_impl_style": "hls"
   },
-  "StreamingMaxPool_0": {
-    "preferred_impl_style": "hls"
-  },
   "ConvolutionInputGenerator_2": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_2": {
+  "Pool_0": {
     "preferred_impl_style": "hls"
   },
   "ConvolutionInputGenerator_3": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_3": {
-    "preferred_impl_style": "hls"
-  },
-  "StreamingMaxPool_1": {
+  "MVAU_2": {
     "preferred_impl_style": "hls"
   },
   "ConvolutionInputGenerator_4": {
     "preferred_impl_style": "rtl"
   },
-  "MVAU_4": {
+  "MVAU_3": {
     "preferred_impl_style": "hls"
   },
   "ConvolutionInputGenerator_5": {
+    "preferred_impl_style": "rtl"
+  },
+  "Pool_1": {
+    "preferred_impl_style": "hls"
+  },
+  "ConvolutionInputGenerator_6": {
+    "preferred_impl_style": "rtl"
+  },
+  "MVAU_4": {
+    "preferred_impl_style": "hls"
+  },
+  "ConvolutionInputGenerator_7": {
     "preferred_impl_style": "rtl"
   },
   "MVAU_5": {
@@ -52,6 +58,9 @@
     "preferred_impl_style": "hls"
   },
   "MVAU_8": {
+    "preferred_impl_style": "hls"
+  },
+  "LabelSelect_0": {
     "preferred_impl_style": "hls"
   }
 }

--- a/build/kws/build.py
+++ b/build/kws/build.py
@@ -61,15 +61,13 @@ build_steps = ["step_preprocess_InsertTopK"] + build_cfg.default_build_dataflow_
 build_outputs = [
     build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
     build_cfg.DataflowOutputType.STITCHED_IP,
-    build_cfg.DataflowOutputType.PYNQ_DRIVER,
     build_cfg.DataflowOutputType.BITFILE,
-    build_cfg.DataflowOutputType.DEPLOYMENT_PACKAGE,
 ]
 
 
 # create a release dir, used for finn-examples release packaging
 os.makedirs("release", exist_ok=True)
-platforms_to_build = ["Pynq-Z1"]
+platforms_to_build = ["AUP-ZU3_8GB"] #["Pynq-Z1"]
 last_output_dir = ""
 for platform_name in platforms_to_build:
     release_platform_name = platform_name

--- a/build/kws/folding_config/kws_folding_config.json
+++ b/build/kws/folding_config/kws_folding_config.json
@@ -1,7 +1,7 @@
 {
   "Defaults": {},
   "MVAU_hls_0": {
-    "PE": 32,
+    "PE": 64,
     "SIMD": 10,
     "ram_style": "auto",
     "resType": "lut",
@@ -26,7 +26,7 @@
   },
   "MVAU_hls_3": {
     "PE": 1,
-    "SIMD": 8,
+    "SIMD": 16,
     "ram_style": "auto",
     "resType": "lut",
     "mem_mode": "internal_decoupled",

--- a/finn_examples/driver.py
+++ b/finn_examples/driver.py
@@ -352,15 +352,18 @@ class FINNExampleOverlay(Overlay):
                 assert self.odma[o].read(0x00) & 0x4 != 0, "Output DMA %d is not idle" % (o)
             # manually launch IODMAs since signatures are missing
             for iwdma, iwbuf, iwdma_name in self.external_weights:
-                iwdma.write(0x10, iwbuf.device_address)
+                iwdma.write(0x10, iwbuf.device_address & 0xFFFFFFFF)
+                iwdma.write(0x14, (iwbuf.device_address >> 32) & 0xFFFFFFFF)
                 iwdma.write(0x1C, batch_size)
                 iwdma.write(0x00, 1)
             for o in range(self.num_outputs):
-                self.odma[o].write(0x10, self.obuf_packed_device[o].device_address)
+                self.odma[o].write(0x10, self.obuf_packed_device[o].device_address & 0xFFFFFFFF)
+                self.odma[o].write(0x14, (self.obuf_packed_device[o].device_address >> 32) & 0xFFFFFFFF)
                 self.odma[o].write(0x1C, batch_size)
                 self.odma[o].write(0x00, 1)
             for i in range(self.num_inputs):
-                self.idma[i].write(0x10, self.ibuf_packed_device[i].device_address)
+                self.idma[i].write(0x10, self.ibuf_packed_device[i].device_address & 0xFFFFFFFF)
+                self.idma[i].write(0x14, (self.ibuf_packed_device[i].device_address >> 32) & 0xFFFFFFFF)
                 self.idma[i].write(0x1C, batch_size)
                 self.idma[i].write(0x00, 1)
         elif self.platform == "alveo":


### PR DESCRIPTION
# FINN examples on AUP-ZU3
Updated the finn-examples build flow for the AUP-ZU3 board and added 64-bit buffer support to the driver script.

> [!NOTE]
> To build some of the bnn-pynq examples, the timeout limits of the set-fifo-depths simulation must be extended in the code (see [issue #1435](https://github.com/Xilinx/finn/issues/1435)). The rtlsim liveness threshold may also need to be adjusted; this can be done by setting the `LIVENESS_THRESHOLD` env var.

## Tool Version Requirements
- FINN commit [3a0cd1c](https://github.com/Xilinx/finn/commit/3a0cd1c5ae850e4564521cd00414860202d327da) [^3]
- PYNQ v3.1
- Vivado 2024.1

## Examples Overview
| Example | Model Name | AUP-ZU3 | Accuracy | Throughput [im/s] |
|:--------:|:--------:|:--------:|:---------:|:--------:|
| bnn-pynq | tfc-w1a1 | :white_check_mark: | 92.93% | 1089429.6 |
| bnn-pynq | tfc-w1a2 | :white_check_mark: | 94.74% | 1193937.9 |
| bnn-pynq | tfc-w2a2 | :white_check_mark: | 96.60% | 1193598.2 |
| bnn-pynq | cnv-w1a1 | :white_check_mark: | 82.62% | 5310.9 |
| bnn-pynq | cnv-w1a2 | :white_check_mark: | 87.76% | 3029.3 |
| bnn-pynq | cnv-w2a2 | :white_check_mark: | 88.63% | 3030.7 |
| cybersecurity-mlp | unsw_nb15-mlp-w2a2 | :white_check_mark: | 91.87% | 910419.8 |
| kws | kwsmlp-w3a3 | :white_check_mark: | 88.76% | 268671.6 |
| mobilenet-v1[^1] | mobilenetv1-w4a4 | :x: | - | - |
| resnet50[^1] | resnet50_w1a2 | :x: | - | - |
| vgg10-radioml[^2] | radioml_w4a4_small_tidy | :x: | - | - |
| gtsrb-cnn | cnv_1w1a_gtsrb | :white_check_mark: | 94.95% | 7642.0 |


[^1]: Model too large to be built for the AUP-ZU3
[^2]: Dataset too large to run on the AUP-ZU3
[^3]: Needed because: supports 64-bit buffers introduced in PYNQ v3.1 and has AUP-ZU3 board integration in FINN